### PR TITLE
RDKB-57687: Update wifi_hal_radio.h to support data elements schema

### DIFF
--- a/include/wifi_hal_radio.h
+++ b/include/wifi_hal_radio.h
@@ -68,6 +68,16 @@ typedef struct {
     UCHAR punct_acs_threshold;
 } __attribute__((packed)) wifi_radio_11be_puncturing_info_t;
 
+#define MAXNUMNONOPERABLECHANNELS 10
+#define MAXNUMOPERCLASSESPERBAND 20
+typedef struct
+{
+    UINT opClass;                                /**< Global operating Class value */
+    INT maxTxPower;                              /**< Max Tx Power */
+    UINT numberOfNonOperChan;                    /**< Number of Nonoperable channels */
+    UINT nonOperable[MAXNUMNONOPERABLECHANNELS]; /**< Array of Non Operable channel value */
+} __attribute__((packed)) wifi_operating_classes_t;
+
 /**
  * @brief Radio temperature information.
  *
@@ -126,6 +136,8 @@ typedef struct {
     BOOL amsduEnable;
     UINT DFSTimer;
     char radarDetected[256];
+    UINT numOperatingClasses;                                            /**< Number of valid operating classes in the array operatingClasses */
+    wifi_operating_classes_t operatingClasses[MAXNUMOPERCLASSESPERBAND]; /**< Array of supported Operating classes as per Data elements Schema */
 } __attribute__((packed)) wifi_radio_operationParam_t;
 
 /**


### PR DESCRIPTION
Reason for change: In data elements schema, Operating classes supported needs to be advertised. This change is to support that. Test Procedure: 1. Ensure in the radio subdoc Operating classes are added Priority: P1
Risks: low

Change-Id: I1aac679e1bc55a7cd6beb75e1a55f6309caf20ce