### PR TITLE
RDKB-58058: Telemetry and Rbus for Transient Client Management

### DIFF
--- a/include/wifi_hal_ap.h
+++ b/include/wifi_hal_ap.h
@@ -2621,6 +2621,7 @@ typedef struct {
     int  min_num_mgmt_frames;
     char tcm_exp_weightage[32];
     char tcm_gradient_threshold[32];
+    char tcm_client_deny_assoc_info[64];
     wifi_vap_name_t vap_name;
 } __attribute__((packed)) wifi_preassoc_control_t;
 


### PR DESCRIPTION
Impacted Platforms:
OneWifi platforms

Reason for change: Implement Rbus functions for TCM as part of Epic

Test Procedure: Load the build and test the changes as per ACs

Risks: Low

Signed-off-by:Harshavardhan_Pulluru@comcast.com